### PR TITLE
Misstyping fix for Unix

### DIFF
--- a/Skills/Numerics/GaussianDistribution.php
+++ b/Skills/Numerics/GaussianDistribution.php
@@ -2,7 +2,7 @@
 
 namespace Moserware\Numerics;
 
-require_once(dirname(__FILE__) . "/basicmath.php");
+require_once(dirname(__FILE__) . "/BasicMath.php");
 
 /**
  * Computes Gaussian (bell curve) values.


### PR DESCRIPTION
I received a fatal error because basicmath.php couln't be found, so here's the little bugfix if you like :)
cheers
