### PR TITLE
SkillCalculator calls Exception in wrong namespace

### DIFF
--- a/src/Moserware/Skills/SkillCalculator.php
+++ b/src/Moserware/Skills/SkillCalculator.php
@@ -70,7 +70,7 @@ abstract class SkillCalculator
 
         if (!$totalTeams->isInRange($countOfTeams))
         {
-            throw new Exception("Team range is not in range");
+            throw new \Exception("Team range is not in range");
         }
     }
 }


### PR DESCRIPTION
This pull request solves a bug I have been victim of, where PHPSkills fails with the following error message:
`PHP Fatal error:  Class 'Moserware\\Skills\\Exception' not found in [redacted]/PHPSkills/Skills/SkillCalculator.php on line 73`
