### PR TITLE
Fix errors with `count()` on classes which implement the count method.

### DIFF
--- a/src/FactorGraphs/FactorList.php
+++ b/src/FactorGraphs/FactorList.php
@@ -1,9 +1,11 @@
 <?php namespace Moserware\Skills\FactorGraphs;
 
+use Countable;
+
 /**
  * Helper class for computing the factor graph's normalization constant.
  */
-class FactorList
+class FactorList implements Countable
 {
     private $_list = array();
 

--- a/src/HashMap.php
+++ b/src/HashMap.php
@@ -1,9 +1,11 @@
 <?php namespace Moserware\Skills;
 
+use Countable;
+
 /**
  * Basic hashmap that supports object keys.
  */
-class HashMap
+class HashMap implements Countable
 {
     private $_hashToValue = array();
     private $_hashToKey = array();

--- a/src/RatingContainer.php
+++ b/src/RatingContainer.php
@@ -1,6 +1,8 @@
 <?php namespace Moserware\Skills;
 
-class RatingContainer
+use Countable;
+
+class RatingContainer implements Countable
 {
     private $_playerToRating;
 


### PR DESCRIPTION
These classes can be counted useing the `count` method, but in newer PHP
versions it needs to implement the interface to work.